### PR TITLE
Add docker icon to Dockerfiles with extensions

### DIFF
--- a/styles/file-icons.less
+++ b/styles/file-icons.less
@@ -353,7 +353,7 @@
   &[data-name^=".travis"]:before { .travis-icon; .medium-red; }
 
   // Dockerfile icon
-  &[data-name="Dockerfile"]:before { .docker-icon; .dark-blue; }
+  &[data-name^="Dockerfile"]:before { .docker-icon; .dark-blue; }
 
   // XAML icon
   &[data-name$=".xaml"]:before { .code-icon; .medium-blue;   }


### PR DESCRIPTION
Starting from Docker 1.5, you can use any file as a Dockerfile when building a container. When you have several of them, the convention seems to be calling them `Dockerfile.xxx` or `Dockerfile-xxx`.

With this change, such files will have the docker icon.